### PR TITLE
[#4] Add Tag Interface to Admin Recipe Form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'annotate'
+  gem 'pry'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -137,6 +138,9 @@ GEM
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     pg (1.1.3)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     puma (3.12.0)
     rack (2.0.6)
     rack-test (1.1.0)
@@ -233,6 +237,7 @@ DEPENDENCIES
   devise
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pry
   puma (~> 3.11)
   rails (~> 5.2.1)
   rspec-rails

--- a/app/admin/recipes.rb
+++ b/app/admin/recipes.rb
@@ -1,3 +1,74 @@
 ActiveAdmin.register Recipe do
-  permit_params :title, :estimated_time, :instructions
+  form do |f|
+    f.inputs 'Recipe' do
+      f.input :title
+      f.input :estimated_time
+      f.input :instructions
+    end
+
+    f.inputs 'Tags' do
+      f.input :tag_ids, as: :check_boxes, collection: Tag.all, label: "Tags"
+    end
+
+    f.actions
+  end
+
+  index do |f|
+    column :title
+    column :estimated_time
+    column :instructions
+    column ("Tags") { |b| b.tags.map(&:name).join(", ") }
+
+    f.actions
+  end
+
+  show do
+    attributes_table do
+      row :title
+      row :estimated_time
+      row :instructions
+      row ("Tags") { |b| b.tags.map(&:name).join(", ") }
+    end
+  end
+
+  controller do
+    def create
+      @recipe = Recipe.new(recipe_params)
+      tags = params[:recipe].require(:tag_ids).presence
+      tags.each do |tag_id|
+        tag = Tag.find_by(id: tag_id)
+        @recipe.tags << tag if tag
+      end
+      if @recipe.save
+        flash[:notice] = "Recipe successfully created!"
+        redirect_to admin_recipe_path(@recipe.id)
+      else
+        flash[:alert] = "Error! Recipe could not be created."
+        redirect_to admin_recipes_path
+      end
+    end
+
+    def update
+      resource.update_attributes(recipe_params)
+      tags = params[:recipe].require(:tag_ids).presence
+      resource.tags = []
+      tags.each do |tag_id|
+        tag = Tag.find_by(id: tag_id)
+        resource.tags << tag if tag
+      end
+      if resource.save
+        flash[:notice] = "Recipe successfully updated!"
+        redirect_to admin_recipe_path(resource.id)
+      else
+        flash[:alert] = "Error! Recipe could not be updated."
+        redirect_to admin_recipes_path
+      end
+    end
+
+    private
+
+    def recipe_params
+     @recipe_params ||= params.require(:recipe).permit(:estimated_time, :title, :instructions)
+    end
+  end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -119,7 +119,7 @@ ActiveAdmin.setup do |config|
   # This allows your users to comment on any resource registered with Active Admin.
   #
   # You can completely disable comments:
-  # config.comments = false
+  config.comments = false
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'
@@ -129,7 +129,7 @@ ActiveAdmin.setup do |config|
   # config.comments_order = 'created_at ASC'
   #
   # You can disable the menu item for the comments index page:
-  # config.comments_menu = false
+  config.comments_menu = false
   #
   # You can customize the comment menu:
   # config.comments_menu = { parent: 'Admin', priority: 1 }


### PR DESCRIPTION
Closes #4.

This PR updates the new and edit form in ActiveAdmin for `Recipe`s to include a meal's tags. Now an admin user can check or uncheck tags to add or remove them correctly.